### PR TITLE
Move matplotlib from core dependencies to docs/test extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "numba>0.54",
     "sparse>=0.9",
     "numpy",
-    "matplotlib",
     "dill",
     "patsy",
 ]
@@ -67,6 +66,7 @@ docs = [
     "sphinx-togglebutton",
     "ipython",
     "parso>=0.8",
+    "matplotlib",  # For plots in docs notebooks
     "polars",  # For docs examples
     "statsmodels",  # For docs example
 ]
@@ -78,7 +78,8 @@ test = [
     "ipython",
     "pytest-cov",  # For coverage testing
     "dask",
-    'statsmodels'
+    'statsmodels',
+    "matplotlib",  # Required by docs notebooks tested via nbmake
 ]
 performance = [
     "dask",  # For distributed computing


### PR DESCRIPTION
Closes #758

matplotlib is only used in docs/gallery example notebooks; no source file under chainladder/ imports it (the references in chainladder/core/display.py are docstring-only).

- Removed matplotlib from [project] dependencies.
- Added matplotlib to docs extra (used by gallery notebooks).
- Added matplotlib to test extra (nbmake exercises the gallery notebooks).

## Summary of Changes  


## Related GitHub Issue(s)  


## Additional Context for Reviewers  


- [ ] I passed tests locally for both code (`pytest`) and documentation changes (`uv run jb build docs --builder=custom --custom-builder=doctest`)
